### PR TITLE
Modify travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: node_js
 node_js:
 - '6'
 script:
+- git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+- git fetch origin
 - git checkout $TRAVIS_BRANCH || git checkout -b $TRAVIS_BRANCH
 - yarn test
 - yarn run reg-suit -- --verbose --test


### PR DESCRIPTION
Add config and fetch command to disable `--single-branch`.
`TravisCI` clone repository with `--depth` option. It enable `--single-branch` behavior when `--no-single-branch` is not set. ( https://git-scm.com/docs/git-clone#git-clone---depthltdepthgt )

If `--single-branch`  is set, we can not find other branch (e.g. master) with `git show-branch` command. This means `getBaseCommitHash` will fail (https://travis-ci.org/reg-viz/reg-simple-demo/builds/255231032)
